### PR TITLE
Reduce binaries size by enable trimming

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Get .NET application version
         if: github.event.inputs.new_engine_version != ''
         working-directory: GrandChessTree.Client
-        id: get_version
+        id: get_version-input
         run: |
           VERSION=${{ github.event.inputs.new_engine_version }}
           echo "Application version: $VERSION"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,11 @@ name: Release Pipeline
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Application version'
+        default: ''
+        required: false
 permissions:
   contents: write
 
@@ -22,6 +27,7 @@ jobs:
 
       # Get the version from the .csproj file
       - name: Get .NET application version
+        if: github.event.inputs.new_engine_version == ''
         working-directory: GrandChessTree.Client
         id: get_version
         run: |
@@ -29,25 +35,34 @@ jobs:
           echo "Application version: $VERSION"
           echo "::set-output name=version::$VERSION"
 
+      - name: Get .NET application version
+        if: github.event.inputs.new_engine_version != ''
+        working-directory: GrandChessTree.Client
+        id: get_version
+        run: |
+          VERSION=${{ github.event.inputs.new_engine_version }}
+          echo "Application version: $VERSION"
+          echo "::set-output name=version::$VERSION"
+
       - name: Build and Package for Windows
         run: |
           dotnet restore
-          dotnet publish -c Release -r win-x64 --self-contained /p:PublishSingleFile=true -o ../output/win-x64
-          
+          dotnet publish -r win-x64 /p:Release=true ../output/win-x64
+
       - name: Build and Package for Linux
         run: |
           dotnet restore
-          dotnet publish -c Release -r linux-x64 --self-contained /p:PublishSingleFile=true -o ../output/linux-x64
+          dotnet publish -r linux-x64 /p:Release=true -o ../output/linux-x64
 
       - name: Build and Package for Linux ARM
         run: |
           dotnet restore
-          dotnet publish -c Release -r linux-arm64 --self-contained /p:PublishSingleFile=true -p:DefineConstants="ARM" -o ../output/linux-arm64
+          dotnet publish -r linux-arm64 /p:Release=true -p:DefineConstants="ARM" -o ../output/linux-arm64
 
       - name: Build and Package for OSX
         run: |
           dotnet restore
-          dotnet publish -c Release -r osx-x64 --self-contained /p:PublishSingleFile=true -o ../output/osx-x64
+          dotnet publish -r osx-x64 /p:Release=true -o ../output/osx-x64
 
       - name: Build and Package for OSX ARM
         run: |
@@ -87,3 +102,4 @@ jobs:
             ${{ github.workspace }}/output/GrandChessTree_linux_arm64
             ${{ github.workspace }}/output/GrandChessTree_osx_x64
             ${{ github.workspace }}/output/GrandChessTree_osx_arm64
+          draft: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
 
       # Get the version from the .csproj file
       - name: Get .NET application version
-        if: github.event.inputs.new_engine_version == ''
+        if: github.event.inputs.version == ''
         working-directory: GrandChessTree.Client
         id: get_version
         run: |
@@ -36,11 +36,11 @@ jobs:
           echo "::set-output name=version::$VERSION"
 
       - name: Get .NET application version
-        if: github.event.inputs.new_engine_version != ''
+        if: github.event.inputs.version != ''
         working-directory: GrandChessTree.Client
         id: get_version-input
         run: |
-          VERSION=${{ github.event.inputs.new_engine_version }}
+          VERSION=${{ github.event.inputs.version }}
           echo "Application version: $VERSION"
           echo "::set-output name=version::$VERSION"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,11 +2,6 @@ name: Release Pipeline
 
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: 'Application version'
-        default: ''
-        required: false
 permissions:
   contents: write
 
@@ -27,20 +22,10 @@ jobs:
 
       # Get the version from the .csproj file
       - name: Get .NET application version
-        if: github.event.inputs.version == ''
         working-directory: GrandChessTree.Client
         id: get_version
         run: |
-          VERSION=0.0.3
-          echo "Application version: $VERSION"
-          echo "::set-output name=version::$VERSION"
-
-      - name: Get .NET application version
-        if: github.event.inputs.version != ''
-        working-directory: GrandChessTree.Client
-        id: get_version-input
-        run: |
-          VERSION=${{ github.event.inputs.version }}
+          VERSION=0.0.4-eduherminio-1
           echo "Application version: $VERSION"
           echo "::set-output name=version::$VERSION"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
         working-directory: GrandChessTree.Client
         id: get_version
         run: |
-          VERSION=0.0.4-eduherminio-1
+          VERSION=0.0.3
           echo "Application version: $VERSION"
           echo "::set-output name=version::$VERSION"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Build and Package for Windows
         run: |
           dotnet restore
-          dotnet publish -r win-x64 /p:Release=true ../output/win-x64
+          dotnet publish -r win-x64 /p:Release=true -o ../output/win-x64
 
       - name: Build and Package for Linux
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -398,3 +398,6 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# Client config file
+gct_config.json

--- a/GrandChessTree.Client/ConfigManager.cs
+++ b/GrandChessTree.Client/ConfigManager.cs
@@ -57,7 +57,7 @@ namespace GrandChessTree.Client
                 try
                 {
                     string json = File.ReadAllText(ConfigFilePath);
-                    return JsonSerializer.Deserialize<Config>(json) ?? new Config();
+                    return JsonSerializer.Deserialize(json, SourceGenerationContext.Default.Config) ?? new Config();
                 }
                 catch (Exception ex)
                 {
@@ -90,7 +90,7 @@ namespace GrandChessTree.Client
 
         private static void SaveConfig(Config config)
         {
-            string json = JsonSerializer.Serialize(config, new JsonSerializerOptions { WriteIndented = true });
+            string json = JsonSerializer.Serialize(config, SourceGenerationContext.Default.Config);
             File.WriteAllText(ConfigFilePath, json);
             Console.WriteLine("Config saved successfully.");
         }

--- a/GrandChessTree.Client/GrandChessTree.Client.csproj
+++ b/GrandChessTree.Client/GrandChessTree.Client.csproj
@@ -8,6 +8,16 @@
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$(Release.ToLower())'=='true'">
+      <Configuration>Release</Configuration>
+      <SelfContained>true</SelfContained>
+      <PublishSingleFile>true</PublishSingleFile>
+      <PublishTrimmed>true</PublishTrimmed>
+      <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
+      <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+      <CETCompat>false</CETCompat>
+    </PropertyGroup>
+
     <ItemGroup>
       <PackageReference Include="ConsoleTables" Version="2.6.2" />
     </ItemGroup>

--- a/GrandChessTree.Client/SearchItemOrchistrator.cs
+++ b/GrandChessTree.Client/SearchItemOrchistrator.cs
@@ -140,7 +140,7 @@ namespace GrandChessTree.Client
 
             if (response.IsSuccessStatusCode)
             {
-                return await response.Content.ReadFromJsonAsync<PerftTaskResponse[]>();
+                return await response.Content.ReadFromJsonAsync(jsonTypeInfo: SourceGenerationContext.Default.PerftTaskResponseArray);
             }
             else if (response.StatusCode == System.Net.HttpStatusCode.NotFound)
             {
@@ -176,11 +176,7 @@ namespace GrandChessTree.Client
                 return false;
             }
 
-            var response = await _httpClient.PostAsJsonAsync($"api/v1/perft/{_searchDepth}/results", new PerftTaskResultBatch()
-            {
-                Results = results.ToArray()
-            });
-
+            var response = await _httpClient.PostAsJsonAsync($"api/v1/perft/{_searchDepth}/results", new PerftTaskResultBatch{Results = [.. results] }, SourceGenerationContext.Default.PerftTaskResultBatch);
 
             if (!response.IsSuccessStatusCode)
             {

--- a/GrandChessTree.Client/SearchItemPersistence.cs
+++ b/GrandChessTree.Client/SearchItemPersistence.cs
@@ -20,17 +20,14 @@ namespace GrandChessTree.Client
                 return null;
 
             byte[] data = await File.ReadAllBytesAsync(filePath);
-            return JsonSerializer.Deserialize<PerftTask>(Encoding.UTF8.GetString(data));
+            return JsonSerializer.Deserialize(Encoding.UTF8.GetString(data), SourceGenerationContext.Default.PerftTask);
         }
 
         public static async Task Save(PerftTask task)
         {
             string filePath = GetFilePath(task.PerftTaskId);
 
-            string json = JsonSerializer.Serialize(task, new JsonSerializerOptions
-            {
-                WriteIndented = false
-            });
+            string json = JsonSerializer.Serialize(task, SourceGenerationContext.Default.PerftTask);
 
             byte[] data = Encoding.UTF8.GetBytes(json);
             await File.WriteAllBytesAsync(filePath, data);

--- a/GrandChessTree.Client/SourceGenerationContext.cs
+++ b/GrandChessTree.Client/SourceGenerationContext.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+using GrandChessTree.Shared.Api;
+
+namespace GrandChessTree.Client;
+
+[JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Default, WriteIndented = true)]
+[JsonSerializable(typeof(Config))]
+[JsonSerializable(typeof(PerftTask))]
+[JsonSerializable(typeof(PerftTaskResponse[]))]
+[JsonSerializable(typeof(PerftTaskResultBatch))]
+internal sealed partial class SourceGenerationContext : JsonSerializerContext;


### PR DESCRIPTION
- Publish trimmed app
- Fix trimming warnings by using source-generator based `System.Text.Json` serialization
- Move release configuration to client project file under a flag

Kinda unrelated (happy to revert)
- Ignore local client config file
- Publish releases as draft, so that you can have a chance to edit the description or experiment with release pipeline

Result (please test) in https://github.com/eduherminio/grandchesstree/releases/tag/GrandChessTree-0.0.4-eduherminio-1 (notice the significant size reduction)

I tested it for windows