### PR TITLE
Add `version` as `workflow_dispatch` input

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,11 @@ name: Release Pipeline
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Application version'
+        default: '0.0.3'
+        required: false
 permissions:
   contents: write
 
@@ -25,7 +30,7 @@ jobs:
         working-directory: GrandChessTree.Client
         id: get_version
         run: |
-          VERSION=0.0.3
+          VERSION=${{ github.event.inputs.version }}
           echo "Application version: $VERSION"
           echo "::set-output name=version::$VERSION"
 


### PR DESCRIPTION
This allows you to override the hardcoded version when running the release pipeline.
If you trust your memory you could even make it required and remove the default value.

![image](https://github.com/user-attachments/assets/a75fe674-6ad6-408f-9d07-4c2bf9e80a37)
